### PR TITLE
Add Getting Started Templates for the Prometheus Pipeline

### DIFF
--- a/examples/eks/prometheus-pipeline/eks-prometheus-sidecar.yaml
+++ b/examples/eks/prometheus-pipeline/eks-prometheus-sidecar.yaml
@@ -152,7 +152,7 @@ spec:
       - command:
           - "/awscollector"
           - "--config=/conf/adot-collector-config.yaml"
-        image: PUBLIC_AWS_COLLECTOR_IMAGE
+        image: public.ecr.aws/aws-observability/aws-otel-collector:latest
         name: adot-collector
         resources:
           limits:

--- a/examples/eks/prometheus-pipeline/eks-prometheus-sidecar.yaml
+++ b/examples/eks/prometheus-pipeline/eks-prometheus-sidecar.yaml
@@ -1,0 +1,184 @@
+---
+# create adot-col namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: adot-col
+  labels:
+    name: adot-col
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: adot-collector-conf
+  namespace: adot-col
+  labels:
+    app: aws-adot
+    component: adot-collector-conf
+data:
+  adot-collector-config: |
+    receivers:
+      prometheus:
+        config:
+          global:
+            scrape_interval: 15s
+            scrape_timeout: 10s
+
+          scrape_configs:
+          - job_name: 'kubernetes-service-endpoints'
+
+            kubernetes_sd_configs:
+            - role: endpoints
+
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+            relabel_configs:
+            - source_labels: [__meta_kubernetes_service_annotation_scrape]
+              action: keep
+              regex: true
+
+    exporters:
+      awsprometheusremotewrite:
+        # replace this with your endpoint
+        endpoint: "YOUR_ENDPOINT"
+        # replace this with your region
+        aws_auth:
+          region: "YOUR_REGION"
+          service: "aps"
+        namespace: "adot"
+      logging:
+        loglevel: debug
+
+    extensions:
+      health_check:
+      pprof:
+        endpoint: :1888
+      zpages:
+        endpoint: :55679
+
+    service:
+      extensions: [pprof, zpages, health_check]
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          exporters: [logging, awsprometheusremotewrite]
+---
+# create adot-col service account and role binding
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: adotcol-admin
+  namespace: adot-col
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: adotcol-admin-role
+rules:
+  - apiGroups: [""]
+    resources:
+    - nodes
+    - nodes/proxy
+    - services
+    - endpoints
+    - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+    - extensions
+    resources:
+    - ingresses
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: adotcol-admin-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: adotcol-admin
+    namespace: adot-col
+roleRef:
+  kind: ClusterRole
+  name: adotcol-admin-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: adot-collector
+  namespace: adot-col
+  labels:
+    app: aws-adot
+    component: adot-collector
+spec:
+  ports:
+  - name: metrics # Default endpoint for querying metrics.
+    port: 8888
+  selector:
+    component: adot-collector
+  type: NodePort
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: adot-collector
+  namespace: adot-col
+  labels:
+    app: aws-adot
+    component: adot-collector
+spec:
+  selector:
+    matchLabels:
+      app: aws-adot
+      component: adot-collector
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        app: aws-adot
+        component: adot-collector
+    spec:
+      serviceAccountName: adotcol-admin
+      containers:
+      - command:
+          - "/awscollector"
+          - "--config=/conf/adot-collector-config.yaml"
+        image: PUBLIC_AWS_COLLECTOR_IMAGE
+        name: adot-collector
+        resources:
+          limits:
+            cpu: 1
+            memory: 2Gi
+          requests:
+            cpu: 200m
+            memory: 400Mi
+        ports:
+        - containerPort: 8888  # Default endpoint for querying metrics.
+        volumeMounts:
+        - name: adot-collector-config-vol
+          mountPath: /conf
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+      volumes:
+        - configMap:
+            name: adot-collector-conf
+            items:
+              - key: adot-collector-config
+                path: adot-collector-config.yaml
+          name: adot-collector-config-vol
+---

--- a/examples/eks/prometheus-pipeline/prometheus-blackbox-exporter.yaml
+++ b/examples/eks/prometheus-pipeline/prometheus-blackbox-exporter.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: blackbox-exporter-deployment
+  namespace: otelcol
+  labels:
+    app: blackbox-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: blackbox-exporter
+  template:
+    metadata:
+      labels:
+        app: blackbox-exporter
+    spec:
+      serviceAccountName: otelcol-admin
+      containers:
+      - name: blackbox-exporter-cont
+        image: prom/blackbox-exporter
+        ports:
+        - name: web
+          containerPort: 9115
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: blackbox-exporter-service
+  namespace: otelcol
+  labels:
+    app: blackbox-exporter
+spec:
+  ports:
+  - name: web
+    port: 9115
+    targetPort: 9115
+    protocol: TCP
+  selector:
+    app: blackbox-exporter
+  type: NodePort
+---

--- a/examples/eks/prometheus-pipeline/prometheus-sample-app.yaml
+++ b/examples/eks/prometheus-pipeline/prometheus-sample-app.yaml
@@ -26,7 +26,8 @@ spec:
     spec:
       containers:
       - name: prometheus-sample-app
-        image: {{PUBLIC_SAMPLE_APP_IMAGE}}
+        image: "" # change to your local image
+        command: ["/bin/main", "-listen_address=0.0.0.0:8080", "-metric_count=10"]
         ports:
         - name: web
           containerPort: 8080

--- a/examples/eks/prometheus-pipeline/prometheus-sample-app.yaml
+++ b/examples/eks/prometheus-pipeline/prometheus-sample-app.yaml
@@ -1,0 +1,52 @@
+---
+# create a namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aoc-prometheus-pipeline-demo
+  labels:
+    name: prometheus-sample-app
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-sample-app
+  namespace: aoc-prometheus-pipeline-demo
+  labels:
+    app: prometheus-sample-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus-sample-app
+  template:
+    metadata:
+      labels:
+        app: prometheus-sample-app
+    spec:
+      containers:
+      - name: prometheus-sample-app
+        image: {{PUBLIC_SAMPLE_APP_IMAGE}}
+        ports:
+        - name: web
+          containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-sample-app-service
+  namespace: aoc-prometheus-pipeline-demo
+  labels:
+    app: prometheus-sample-app
+  annotations:
+    scrape: "true"
+spec:
+  ports:
+  - name: web
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app: prometheus-sample-app
+  type: NodePort
+---


### PR DESCRIPTION
**Creating the PR here for now until we get the sample app published as a public image**

**Description:**
Adding getting started templates for the Prometheus pipeline. It consists of a sample app deployment and an AOC deployment (as a DaemonSet). AOC will use the Prometheus Receiver and AWS Prometheus Remote Write Exporter.