### PR TITLE
Add AWS PRW exporter to lambda components

### DIFF
--- a/pkg/lambdacomponents/defaults.go
+++ b/pkg/lambdacomponents/defaults.go
@@ -13,51 +13,53 @@
  * permissions and limitations under the License.
  */
 
- package lambdacomponents
+package lambdacomponents
 
- import (
-	 "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter"
-	 "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter"
-	 "go.opentelemetry.io/collector/component"
-	 "go.opentelemetry.io/collector/consumer/consumererror"
-	 "go.opentelemetry.io/collector/exporter/loggingexporter"
-	 "go.opentelemetry.io/collector/exporter/otlpexporter"
-	 "go.opentelemetry.io/collector/exporter/otlphttpexporter"
-	 "go.opentelemetry.io/collector/exporter/prometheusexporter"
-	 "go.opentelemetry.io/collector/receiver/otlpreceiver"
- )
- 
- // Components returns a set of stripped components used by the
- // OpenTelemetry collector built for Lambda env.
- func Components() (
-	 component.Factories,
-	 error,
- ) {
-	 var errs []error
- 
-	 receivers, err := component.MakeReceiverFactoryMap(
-		 otlpreceiver.NewFactory(),
-	 )
-	 if err != nil {
-		 errs = append(errs, err)
-	 }
- 
-	 exporters, err := component.MakeExporterFactoryMap(
-		 awsxrayexporter.NewFactory(),
-		 awsemfexporter.NewFactory(),
-		 prometheusexporter.NewFactory(),
-		 loggingexporter.NewFactory(),
-		 otlpexporter.NewFactory(),
-		 otlphttpexporter.NewFactory(),
-	 )
-	 if err != nil {
-		 errs = append(errs, err)
-	 }
- 
-	 factories := component.Factories{
-		 Receivers:  receivers,
-		 Exporters:  exporters,
-	 }
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsprometheusremotewriteexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter/loggingexporter"
+	"go.opentelemetry.io/collector/exporter/otlpexporter"
+	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
+	"go.opentelemetry.io/collector/exporter/prometheusexporter"
+	"go.opentelemetry.io/collector/receiver/otlpreceiver"
+)
 
-	 return factories, consumererror.Combine(errs)
- }
+// Components returns a set of stripped components used by the
+// OpenTelemetry collector built for Lambda env.
+func Components() (
+	component.Factories,
+	error,
+) {
+	var errs []error
+
+	receivers, err := component.MakeReceiverFactoryMap(
+		otlpreceiver.NewFactory(),
+	)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	exporters, err := component.MakeExporterFactoryMap(
+		awsxrayexporter.NewFactory(),
+		awsemfexporter.NewFactory(),
+		awsprometheusremotewriteexporter.NewFactory(),
+		prometheusexporter.NewFactory(),
+		loggingexporter.NewFactory(),
+		otlpexporter.NewFactory(),
+		otlphttpexporter.NewFactory(),
+	)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	factories := component.Factories{
+		Receivers: receivers,
+		Exporters: exporters,
+	}
+
+	return factories, consumererror.Combine(errs)
+}

--- a/pkg/lambdacomponents/defaults_test.go
+++ b/pkg/lambdacomponents/defaults_test.go
@@ -28,6 +28,8 @@ func TestComponents(t *testing.T) {
 	exporters := factories.Exporters
 	// aws exporters
 	assert.True(t, exporters["awsxray"] != nil)
+	assert.True(t, exporters["awsprometheusremotewrite"] != nil)
+
 	// core exporters
 	assert.True(t, exporters["logging"] != nil)
 	assert.True(t, exporters["otlphttp"] != nil)

--- a/pkg/lambdacomponents/go.mod
+++ b/pkg/lambdacomponents/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.29.1-0.20210630203112-81d57601b1bc
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.29.1-0.20210630203112-81d57601b1bc
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsprometheusremotewriteexporter v0.29.1-0.20210630203112-81d57601b1bc
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.29.1-0.20210630003519-14d917479ef3
 )


### PR DESCRIPTION
### Description

Adds the AWS Prometheus Remote Write (PRW) exporter into the lambda components so that the lambda layer in aws-otel-lambda is available when created using this repository.