### PR TITLE
Enable the resource_to_telemetry_conversion to true in amp config.yaml files

### DIFF
--- a/config/ecs/ecs-amp-prometheus.yaml
+++ b/config/ecs/ecs-amp-prometheus.yaml
@@ -40,6 +40,8 @@ processors:
 exporters:
   awsprometheusremotewrite:
     endpoint: $AWS_PROMETHEUS_ENDPOINT
+    resource_to_telemetry_conversion:
+      enabled: true
 
 service:
   pipelines:

--- a/config/ecs/ecs-amp-xray-prometheus.yaml
+++ b/config/ecs/ecs-amp-xray-prometheus.yaml
@@ -50,6 +50,8 @@ exporters:
   awsxray:
   awsprometheusremotewrite:
     endpoint: $AWS_PROMETHEUS_ENDPOINT
+    resource_to_telemetry_conversion:
+      enabled: true
 
 service:
   pipelines:

--- a/config/ecs/ecs-amp-xray.yaml
+++ b/config/ecs/ecs-amp-xray.yaml
@@ -41,6 +41,8 @@ exporters:
   awsxray:
   awsprometheusremotewrite:
     endpoint: $AWS_PROMETHEUS_ENDPOINT
+    resource_to_telemetry_conversion:
+      enabled: true
 
 service:
   pipelines:

--- a/config/ecs/ecs-amp.yaml
+++ b/config/ecs/ecs-amp.yaml
@@ -37,6 +37,8 @@ processors:
 exporters:
   awsprometheusremotewrite:
     endpoint: $AWS_PROMETHEUS_ENDPOINT
+    resource_to_telemetry_conversion:
+      enabled: true
 
 service:
   pipelines:


### PR DESCRIPTION
This PR will add dimensions/tags and more detailed information to AMP metrics which helps to identify the metrics using cluster_name, task_id

Modified the following ecs-amp config files by enabling the resource_to_telemetry_conversion to true

Paths to config files 
config/ecs/ecs-amp.yaml
config/ecs/ecs-amp-xray.yaml
config/ecs/ecs-amp-xray-prometheus.yaml
config/ecs/ecs-amp-prometheus.yaml